### PR TITLE
refactor: removing the dependency on @readme/syntax-highlighter

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -8,8 +8,6 @@ const harExamples = require('har-examples');
 const generateCodeSnippet = require('../src');
 const supportedLanguages = require('../src/supportedLanguages');
 
-const { getLangName } = generateCodeSnippet;
-
 const oas = new Oas();
 const petstoreOas = new Oas(petstore);
 
@@ -371,34 +369,5 @@ describe('supported languages', () => {
 
     expect(snippet.code).toStrictEqual(expect.stringMatching('node-fetch'));
     expect(snippet.highlightMode).toBe('javascript');
-  });
-});
-
-describe('#getLangName()', () => {
-  it('should convert name to correct case', () => {
-    expect(getLangName('c')).toBe('C');
-    expect(getLangName('cplusplus')).toBe('C++');
-    expect(getLangName('csharp')).toBe('C#');
-    expect(getLangName('clojure')).toBe('Clojure');
-    expect(getLangName('curl')).toBe('cURL');
-    expect(getLangName('go')).toBe('Go');
-    expect(getLangName('java')).toBe('Java');
-    expect(getLangName('javascript')).toBe('JavaScript');
-    expect(getLangName('kotlin')).toBe('Kotlin');
-    expect(getLangName('node')).toBe('Node');
-    expect(getLangName('node-simple')).toBe('Node (simple)');
-    expect(getLangName('objectivec')).toBe('Objective-C');
-    expect(getLangName('ocaml')).toBe('OCaml');
-    expect(getLangName('php')).toBe('PHP');
-    expect(getLangName('powershell')).toBe('PowerShell');
-    expect(getLangName('python')).toBe('Python');
-    expect(getLangName('r')).toBe('R');
-    expect(getLangName('ruby')).toBe('Ruby');
-    expect(getLangName('swift')).toBe('Swift');
-  });
-
-  it('should pass through unknown values', () => {
-    expect(getLangName('HTTP')).toBe('HTTP');
-    expect(getLangName('unknown')).toBe('unknown');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@readme/oas-to-snippet",
-  "version": "13.6.1",
+  "version": "13.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/oas-to-snippet",
-      "version": "13.6.1",
+      "version": "13.6.2",
       "license": "MIT",
       "dependencies": {
         "@readme/httpsnippet": "^2.5.1",
         "@readme/oas-extensions": "^13.6.0",
         "@readme/oas-to-har": "^13.6.0",
-        "@readme/syntax-highlighter": "^10.10.1",
         "httpsnippet-client-api": "^3.3.0",
         "oas": "^14.0.0"
       },
@@ -2045,38 +2044,6 @@
         "npm": "^7"
       }
     },
-    "node_modules/@readme/syntax-highlighter": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
-      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
-      "dependencies": {
-        "codemirror": "^5.48.2",
-        "prop-types": "^15.7.2",
-        "react-codemirror2": "^7.2.1"
-      },
-      "peerDependencies": {
-        "@readme/variable": "*",
-        "react": "16.x",
-        "react-dom": "16.x"
-      }
-    },
-    "node_modules/@readme/variable": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.1.tgz",
-      "integrity": "sha512-f6rFMO1EcAU84de1/O8urrrJAsu4PSPEMMW6QB6zo4XJiBwIaUbUXOhLE7vX/c0LfHbe0bCwUx5OuWuMibUXqQ==",
-      "peer": true,
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
-      },
-      "peerDependencies": {
-        "react": "16.x"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -3285,12 +3252,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "peer": true
-    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -3360,11 +3321,6 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
-    },
-    "node_modules/codemirror": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -8466,7 +8422,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.0",
@@ -8842,6 +8799,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -9544,6 +9502,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10002,6 +9961,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -10055,44 +10015,11 @@
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
     },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-codemirror2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "2.0.0",
@@ -10386,16 +10313,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {
@@ -13122,26 +13039,6 @@
         "parse-data-url": "^4.0.1"
       }
     },
-    "@readme/syntax-highlighter": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
-      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
-      "requires": {
-        "codemirror": "^5.48.2",
-        "prop-types": "^15.7.2",
-        "react-codemirror2": "^7.2.1"
-      }
-    },
-    "@readme/variable": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.1.tgz",
-      "integrity": "sha512-f6rFMO1EcAU84de1/O8urrrJAsu4PSPEMMW6QB6zo4XJiBwIaUbUXOhLE7vX/c0LfHbe0bCwUx5OuWuMibUXqQ==",
-      "peer": true,
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -14051,12 +13948,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "peer": true
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -14104,11 +13995,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codemirror": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-      "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -18059,7 +17945,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -18351,6 +18238,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -18897,7 +18785,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.10.3",
@@ -19237,6 +19126,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -19280,38 +19170,11 @@
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-codemirror2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
-    },
-    "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -19542,16 +19405,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
-      }
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@readme/httpsnippet": "^2.5.1",
     "@readme/oas-extensions": "^13.6.0",
     "@readme/oas-to-har": "^13.6.0",
-    "@readme/syntax-highlighter": "^10.10.1",
     "httpsnippet-client-api": "^3.3.0",
     "oas": "^14.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const HTTPSnippet = require('@readme/httpsnippet');
 const HTTPSnippetSimpleApiClient = require('httpsnippet-client-api');
-const { uppercase } = require('@readme/syntax-highlighter');
 const generateHar = require('@readme/oas-to-har');
 const supportedLanguages = require('./supportedLanguages');
 
@@ -86,14 +85,6 @@ module.exports = (oas, operation, values, auth, lang, oasUrl, harOverride) => {
       highlightMode,
     };
   }
-};
-
-module.exports.getLangName = lang => {
-  if (lang === 'node-simple') {
-    return 'Node (simple)';
-  }
-
-  return uppercase(lang);
 };
 
 module.exports.supportedLanguages = supportedLanguages;


### PR DESCRIPTION
## 🧰 What's being changed?

Removes the dependency on `@readme/syntax-highlighter` and removes the `getLangName` export.

**This is a breaking change!**