### PR TITLE
feat: adding HTTP into our list of supported snippet targets

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -268,6 +268,28 @@ func main() {
 }
 `;
 
+exports[`supported languages http should generate code for the default target 1`] = `
+Object {
+  "code": "POST /v2/pet HTTP/1.1
+Content-Type: application/json
+Host: petstore.swagger.io
+
+",
+  "highlightMode": "http",
+}
+`;
+
+exports[`supported languages http targets 1.1 should support snippet generation 1`] = `
+Object {
+  "code": "GET /v2/user/login?username=woof&password=barkbarkbark HTTP/1.1
+Accept: application/xml
+Host: petstore.swagger.io
+
+",
+  "highlightMode": "http",
+}
+`;
+
 exports[`supported languages java should generate code for the default target 1`] = `
 Object {
   "code": "OkHttpClient client = new OkHttpClient();

--- a/src/supportedLanguages.js
+++ b/src/supportedLanguages.js
@@ -59,6 +59,16 @@ module.exports = {
       },
     },
   },
+  http: {
+    highlight: 'http',
+    httpsnippet: {
+      lang: 'http',
+      default: '1.1',
+      targets: {
+        1.1: { name: 'HTTP 1.1' },
+      },
+    },
+  },
   go: {
     highlight: 'go',
     httpsnippet: {


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Adds `http` into our list of supported snippet targets.

Work in support of RM-2473.

## 🧬 Testing

See tests.