### PR TITLE
feat: rename curl to shell

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -62,6 +62,26 @@ exports[`should have special indents for curl snippets 1`] = `
      --data 'b=1,2,3'"
 `;
 
+exports[`supported languages backwards compatibiltiy should still support \`curl\` as the supplied language 1`] = `
+Object {
+  "code": "curl --request GET \\\\
+     --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\\\
+     --header 'Accept: application/xml'",
+  "highlightMode": "shell",
+}
+`;
+
+exports[`supported languages backwards compatibiltiy should still support \`node-simple\` as the supplied language 1`] = `
+Object {
+  "code": "const sdk = require('api')('https://example.com/openapi.json');
+
+sdk.loginUser({username: 'woof', password: 'barkbarkbark', Accept: 'application/xml'})
+  .then(res => console.log(res))
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+}
+`;
+
 exports[`supported languages c should generate code for the default target 1`] = `
 Object {
   "code": "CURL *hnd = curl_easy_init();
@@ -185,24 +205,6 @@ var request = new RestRequest(Method.GET);
 request.AddHeader(\\"Accept\\", \\"application/xml\\");
 IRestResponse response = client.Execute(request);",
   "highlightMode": "text/x-csharp",
-}
-`;
-
-exports[`supported languages curl should generate code for the default target 1`] = `
-Object {
-  "code": "curl --request POST \\\\
-     --url http://petstore.swagger.io/v2/pet \\\\
-     --header 'Content-Type: application/json'",
-  "highlightMode": "shell",
-}
-`;
-
-exports[`supported languages curl targets curl should support snippet generation 1`] = `
-Object {
-  "code": "curl --request GET \\\\
-     --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\\\
-     --header 'Accept: application/xml'",
-  "highlightMode": "shell",
 }
 `;
 
@@ -859,6 +861,32 @@ request[\\"Accept\\"] = 'application/xml'
 response = http.request(request)
 puts response.read_body",
   "highlightMode": "ruby",
+}
+`;
+
+exports[`supported languages shell should generate code for the default target 1`] = `
+Object {
+  "code": "curl --request POST \\\\
+     --url http://petstore.swagger.io/v2/pet \\\\
+     --header 'Content-Type: application/json'",
+  "highlightMode": "shell",
+}
+`;
+
+exports[`supported languages shell targets curl should support snippet generation 1`] = `
+Object {
+  "code": "curl --request GET \\\\
+     --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\\\
+     --header 'Accept: application/xml'",
+  "highlightMode": "shell",
+}
+`;
+
+exports[`supported languages shell targets httpie should support snippet generation 1`] = `
+Object {
+  "code": "http GET 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\\\
+  Accept:application/xml",
+  "highlightMode": "shell",
 }
 `;
 

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -268,6 +268,28 @@ func main() {
 }
 `;
 
+exports[`supported languages http should generate code for the default target 1`] = `
+Object {
+  "code": "POST /v2/pet HTTP/1.1
+Content-Type: application/json
+Host: petstore.swagger.io
+
+",
+  "highlightMode": "http",
+}
+`;
+
+exports[`supported languages http targets 1.1 should support snippet generation 1`] = `
+Object {
+  "code": "GET /v2/user/login?username=woof&password=barkbarkbark HTTP/1.1
+Accept: application/xml
+Host: petstore.swagger.io
+
+",
+  "highlightMode": "http",
+}
+`;
+
 exports[`supported languages java should generate code for the default target 1`] = `
 Object {
   "code": "OkHttpClient client = new OkHttpClient();

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -346,20 +346,21 @@ describe('supported languages', () => {
     });
   });
 
-  it('should support `node-simple`', () => {
-    const snippet = generateCodeSnippet(
-      petstore,
-      petstore.operation('/user/login', 'get'),
-      {
-        query: { username: 'woof', password: 'barkbarkbark' },
-      },
-      {},
-      'node-simple',
-      oasUrl
-    );
+  describe('backwards compatibiltiy', () => {
+    it.each([['curl'], ['node-simple']])('should still support `%s` as the supplied language', lang => {
+      const snippet = generateCodeSnippet(
+        petstore,
+        petstore.operation('/user/login', 'get'),
+        {
+          query: { username: 'woof', password: 'barkbarkbark' },
+        },
+        {},
+        lang,
+        oasUrl
+      );
 
-    expect(snippet.code).toStrictEqual(expect.stringMatching('https://example.com/openapi.json'));
-    expect(snippet.highlightMode).toBe('javascript');
+      expect(snippet).toMatchSnapshot();
+    });
   });
 
   it('should gracefully fallback to `fetch` snippets if our `api` target fails', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,10 @@ module.exports = (oas, operation, values, auth, lang, oasUrl, harOverride) => {
     config = supportedLanguages.node;
     language = 'node';
     target = 'api';
+  } else if (lang === 'curl') {
+    config = supportedLanguages.shell;
+    language = 'shell';
+    target = 'curl';
   } else if (Array.isArray(lang)) {
     if (lang[0] in supportedLanguages) {
       if (lang[1] in supportedLanguages[lang[0]].httpsnippet.targets) {

--- a/src/supportedLanguages.js
+++ b/src/supportedLanguages.js
@@ -59,6 +59,16 @@ module.exports = {
       },
     },
   },
+  http: {
+    highlight: 'http',
+    httpsnippet: {
+      lang: 'http',
+      default: '1.1',
+      targets: {
+        1.1: { name: 'HTTP 1.1' },
+      },
+    },
+  },
   go: {
     highlight: 'go',
     httpsnippet: {

--- a/src/supportedLanguages.js
+++ b/src/supportedLanguages.js
@@ -43,22 +43,6 @@ module.exports = {
       },
     },
   },
-  curl: {
-    highlight: 'shell',
-    httpsnippet: {
-      lang: 'shell',
-      default: 'curl',
-      targets: {
-        curl: {
-          name: 'cURL',
-          opts: {
-            escapeBrackets: true,
-            indent: '     ',
-          },
-        },
-      },
-    },
-  },
   http: {
     highlight: 'http',
     httpsnippet: {
@@ -226,6 +210,23 @@ module.exports = {
       default: 'ruby',
       targets: {
         ruby: { name: 'net::http' },
+      },
+    },
+  },
+  shell: {
+    highlight: 'shell',
+    httpsnippet: {
+      lang: 'shell',
+      default: 'curl',
+      targets: {
+        curl: {
+          name: 'cURL',
+          opts: {
+            escapeBrackets: true,
+            indent: '     ',
+          },
+        },
+        httpie: { name: 'HTTPie' },
       },
     },
   },


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Renames our main `curl` target to now be a nested target within `shell`.
  * Backwards compatibility and supplying just `curl` as the main language instead of `['shell', 'curl']` is retained.
* [x] Adds support for generating [HTTPie](https://httpie.io/) snippets.

Work in support of RM-2473.

## 🧬 Testing

See tests.