### PR TITLE
fix: upgrading snippet deps to fix a bug with multipart/form-data requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "15.0.2",
       "license": "MIT",
       "dependencies": {
-        "@readme/httpsnippet": "^3.0.0",
-        "@readme/oas-to-har": "^14.0.1",
-        "httpsnippet-client-api": "^4.1.0"
+        "@readme/httpsnippet": "^3.0.1",
+        "@readme/oas-to-har": "^14.0.2",
+        "httpsnippet-client-api": "^4.1.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^15.0.0",
@@ -24,7 +24,7 @@
         "har-examples": "^2.0.1",
         "husky": "^7.0.4",
         "jest": "^27.3.1",
-        "oas": "^17.1.0",
+        "oas": "^17.1.7",
         "prettier": "^2.4.1"
       },
       "engines": {
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.0.tgz",
-      "integrity": "sha512-v6/oCr1nkaYGbCl6blMF51WrOwlEJVZ/D050KQi1kxhD3X2d02FYUUUw1ERAzFjXRmrWI2U0H5NE2IWsiqXvSg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.1.tgz",
+      "integrity": "sha512-sDB2vKjAUCHfNbLl2LeLZmaTsEuoDwwVVRAtN3nkGjvoAH/qEW46N/GNr98D9ecWDUFYatMVyOi4ZyqzNy7KXw==",
       "dependencies": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
@@ -1962,9 +1962,9 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.1.tgz",
-      "integrity": "sha512-eIGx6+TDQZGVO01qXIk5gcGmhfaMW2BBxu1UeXoaWe1xMwMnwq4Cp1gAhh8ukw8cxlzPos6IakTPPamfYxD4dQ==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.2.tgz",
+      "integrity": "sha512-/8FG5C4l06dPwb12KyC33wYRX6H+yvOZaFT8cA66/NzRk+MAZDwPvmVOaFcVpdW4lqptT+Xgf2GO43HhoHceKg==",
       "dependencies": {
         "@readme/oas-extensions": "^14.0.0",
         "oas": "^17.1.0",
@@ -5571,9 +5571,9 @@
       }
     },
     "node_modules/httpsnippet-client-api": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-4.1.0.tgz",
-      "integrity": "sha512-+1BXCbZq5BoH1SWG4sh2eZEliBl+ijiqjxq1tkfrR9EyMZsmoqxscMYKraL34n5iD0Hce9nYImNKJgIwYy7/qQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-4.1.2.tgz",
+      "integrity": "sha512-Pg+xubIYbqY4kwsK4+I1l+5ulXQj49LSCzEom0ZaJVax3TCvrubq6B1uBBf0FoMcL2S7ghdGX5kZxokD1jra/A==",
       "dependencies": {
         "content-type": "^1.0.4",
         "path-to-regexp": "^6.1.0",
@@ -8936,9 +8936,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.6.tgz",
-      "integrity": "sha512-HcTKfE5nE6y6ipjQf7mkE/yTsXALDa7EpsUHwPEVtadlC374PSg6ngXd1w03klSfiZAbWD5aBNbOAhbZ6algIg==",
+      "version": "17.1.7",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.7.tgz",
+      "integrity": "sha512-BWXhaJPC0OywIpSRKcD6dIhyCqBQOkUBpKcx7bQ1yz9WG3k5T0ooC8E/Co/ywK28txTqHG2PSisxw2Xb1J4y/w==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -12515,9 +12515,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.0.tgz",
-      "integrity": "sha512-v6/oCr1nkaYGbCl6blMF51WrOwlEJVZ/D050KQi1kxhD3X2d02FYUUUw1ERAzFjXRmrWI2U0H5NE2IWsiqXvSg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-3.0.1.tgz",
+      "integrity": "sha512-sDB2vKjAUCHfNbLl2LeLZmaTsEuoDwwVVRAtN3nkGjvoAH/qEW46N/GNr98D9ecWDUFYatMVyOi4ZyqzNy7KXw==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
@@ -12559,9 +12559,9 @@
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.1.tgz",
-      "integrity": "sha512-eIGx6+TDQZGVO01qXIk5gcGmhfaMW2BBxu1UeXoaWe1xMwMnwq4Cp1gAhh8ukw8cxlzPos6IakTPPamfYxD4dQ==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.2.tgz",
+      "integrity": "sha512-/8FG5C4l06dPwb12KyC33wYRX6H+yvOZaFT8cA66/NzRk+MAZDwPvmVOaFcVpdW4lqptT+Xgf2GO43HhoHceKg==",
       "requires": {
         "@readme/oas-extensions": "^14.0.0",
         "oas": "^17.1.0",
@@ -15309,9 +15309,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-4.1.0.tgz",
-      "integrity": "sha512-+1BXCbZq5BoH1SWG4sh2eZEliBl+ijiqjxq1tkfrR9EyMZsmoqxscMYKraL34n5iD0Hce9nYImNKJgIwYy7/qQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-4.1.2.tgz",
+      "integrity": "sha512-Pg+xubIYbqY4kwsK4+I1l+5ulXQj49LSCzEom0ZaJVax3TCvrubq6B1uBBf0FoMcL2S7ghdGX5kZxokD1jra/A==",
       "requires": {
         "content-type": "^1.0.4",
         "path-to-regexp": "^6.1.0",
@@ -17911,9 +17911,9 @@
       "dev": true
     },
     "oas": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.6.tgz",
-      "integrity": "sha512-HcTKfE5nE6y6ipjQf7mkE/yTsXALDa7EpsUHwPEVtadlC374PSg6ngXd1w03klSfiZAbWD5aBNbOAhbZ6algIg==",
+      "version": "17.1.7",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.7.tgz",
+      "integrity": "sha512-BWXhaJPC0OywIpSRKcD6dIhyCqBQOkUBpKcx7bQ1yz9WG3k5T0ooC8E/Co/ywK28txTqHG2PSisxw2Xb1J4y/w==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^3.0.0",
-    "@readme/oas-to-har": "^14.0.1",
-    "httpsnippet-client-api": "^4.1.0"
+    "@readme/httpsnippet": "^3.0.1",
+    "@readme/oas-to-har": "^14.0.2",
+    "httpsnippet-client-api": "^4.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
@@ -37,7 +37,7 @@
     "har-examples": "^2.0.1",
     "husky": "^7.0.4",
     "jest": "^27.3.1",
-    "oas": "^17.1.0",
+    "oas": "^17.1.7",
     "prettier": "^2.4.1"
   },
   "prettier": "@readme/eslint-config/prettier",


### PR DESCRIPTION
## 🧰 What's being changed?

This updates `@readme/httpsnippet` and `httpsnippet-client-api` to fix a bug wtih `mutlipart/form-data` requests where if their HAR didn't have a `postData.params` some language targets would crash.

## 🧬 Testing

See https://github.com/readmeio/api/pull/360 and https://github.com/readmeio/httpsnippet/pull/65 for details + tests.