### PR TITLE
fix: cleaning up engine requirements and updating dev deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install npm@7
-        run: npm install -g npm@7
-
       - name: Install deps
         run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@readme/httpsnippet": "^3.0.1",
-        "@readme/oas-to-har": "^14.0.2",
+        "@readme/oas-to-har": "^14.0.4",
         "httpsnippet-client-api": "^4.1.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^15.0.0",
         "@commitlint/config-conventional": "^15.0.0",
-        "@readme/eslint-config": "^8.0.2",
+        "@readme/eslint-config": "^8.0.4",
         "@readme/oas-examples": "^4.3.2",
-        "@readme/oas-extensions": "^14.0.0",
+        "@readme/oas-extensions": "^14.0.3",
         "datauri": "^4.1.0",
         "eslint": "^8.2.0",
         "har-examples": "^2.0.1",
@@ -28,8 +28,7 @@
         "prettier": "^2.4.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -156,9 +155,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
-      "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz",
+      "integrity": "sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==",
       "dev": true,
       "dependencies": {
         "eslint-scope": "^5.1.1",
@@ -1114,6 +1113,14 @@
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -1837,12 +1844,13 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -1871,9 +1879,9 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.0.2.tgz",
-      "integrity": "sha512-8mZLZ8lXuyj0w7+4K3+apxZU35wMFnDucaKqv7H6ag3OGuuIqU4FNH6SIXu+H6cKeg12CZNmJfKtB3ZWfWyKAA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.0.4.tgz",
+      "integrity": "sha512-0JqJIS3kjgeztyUsLEpmxeYb6sHXKaUaDCHfmqfh2GEVAUhviQ7KZt2Pe0B6Ix3UHv2AYZs3DeE0JrC6JXjY/A==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.4.0",
@@ -1892,12 +1900,11 @@
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-testing-library": "^5.0.0",
-        "eslint-plugin-unicorn": "^38.0.0",
+        "eslint-plugin-unicorn": "^39.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       },
       "engines": {
-        "node": "^12 || ^14",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -1943,6 +1950,33 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@readme/oas-examples": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
@@ -1950,41 +1984,39 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.1.tgz",
-      "integrity": "sha512-neF3axz+FUP/tYkBUIrubWUGnQJ2nWeFlf4T6oDJKMOE5cHdV4kboEYHwXnz/DBO0JuO8baFZoxX5Pp/nv+r/g==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.3.tgz",
+      "integrity": "sha512-Z2bDImkmNSzHK98Rga5fTThculu3vF0Yhcr7/L8Sux1j+msPrkj6LoV0nIiG+42GcRoZHe5az8e/1PRTqP5rtA==",
       "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       },
       "peerDependencies": {
         "oas": "^17.1.0"
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.2.tgz",
-      "integrity": "sha512-/8FG5C4l06dPwb12KyC33wYRX6H+yvOZaFT8cA66/NzRk+MAZDwPvmVOaFcVpdW4lqptT+Xgf2GO43HhoHceKg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.4.tgz",
+      "integrity": "sha512-bEXDrzgn17ScrGhzQHwAwosyimq8UzbVs8j72SDmZwxzUAsnGb8x1sOyz2DqCF0GVz0+p3F9jfbq2ii94ILvNQ==",
       "dependencies": {
-        "@readme/oas-extensions": "^14.0.0",
-        "oas": "^17.1.0",
+        "@readme/oas-extensions": "^14.0.3",
+        "oas": "^17.3.2",
         "parse-data-url": "^4.0.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
+        "node": "^12 || ^14 || ^16"
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
@@ -1993,21 +2025,10 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@readme/openapi-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2030,22 +2051,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@readme/openapi-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/json-schema-traverse": {
@@ -3888,11 +3893,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -4564,9 +4564,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "38.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-38.0.1.tgz",
-      "integrity": "sha512-eu4HCg7Bv43nk/hYZoWpLzRo668Nb7swQySn94aohn0heh9KLJ1GOFgVxJndLS8BploMGaClxgsyTNGJrP69yw==",
+      "version": "39.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-39.0.0.tgz",
+      "integrity": "sha512-fd5RK2FtYjGcIx3wra7csIE/wkkmBo22T1gZtRTsLr1Mb+KsFKJ+JOdSqhHXQUrI/JTs/Mon64cEYzTgSCbltw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -6174,6 +6174,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8936,11 +8941,12 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.1.7",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.7.tgz",
-      "integrity": "sha512-BWXhaJPC0OywIpSRKcD6dIhyCqBQOkUBpKcx7bQ1yz9WG3k5T0ooC8E/Co/ywK28txTqHG2PSisxw2Xb1J4y/w==",
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
+      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@types/json-schema": "^7.0.9",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -8950,10 +8956,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^4.1.5"
+        "swagger-inline": "^5.0.2"
       },
       "bin": {
         "oas": "bin/oas"
@@ -8984,11 +8990,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.1.tgz",
-      "integrity": "sha512-GJStwIAjiJdHbzsqI5E492yL5duhG1Mrnbp0smRx5NEN/BkiFqPJDTG7JtI3VBKdHA023TUeCD3/XoKkg5a14g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "dependencies": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -9192,9 +9198,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -10380,9 +10386,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
-      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
+      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -11163,9 +11169,9 @@
       }
     },
     "@babel/eslint-parser": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
-      "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz",
+      "integrity": "sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==",
       "dev": true,
       "requires": {
         "eslint-scope": "^5.1.1",
@@ -11885,6 +11891,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA=="
+    },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -12465,12 +12476,13 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -12489,9 +12501,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.0.2.tgz",
-      "integrity": "sha512-8mZLZ8lXuyj0w7+4K3+apxZU35wMFnDucaKqv7H6ag3OGuuIqU4FNH6SIXu+H6cKeg12CZNmJfKtB3ZWfWyKAA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.0.4.tgz",
+      "integrity": "sha512-0JqJIS3kjgeztyUsLEpmxeYb6sHXKaUaDCHfmqfh2GEVAUhviQ7KZt2Pe0B6Ix3UHv2AYZs3DeE0JrC6JXjY/A==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.4.0",
@@ -12510,7 +12522,7 @@
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-testing-library": "^5.0.0",
-        "eslint-plugin-unicorn": "^38.0.0",
+        "eslint-plugin-unicorn": "^39.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
@@ -12546,70 +12558,17 @@
         }
       }
     },
-    "@readme/oas-examples": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
-      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
-      "dev": true
-    },
-    "@readme/oas-extensions": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.1.tgz",
-      "integrity": "sha512-neF3axz+FUP/tYkBUIrubWUGnQJ2nWeFlf4T6oDJKMOE5cHdV4kboEYHwXnz/DBO0JuO8baFZoxX5Pp/nv+r/g==",
-      "requires": {}
-    },
-    "@readme/oas-to-har": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.2.tgz",
-      "integrity": "sha512-/8FG5C4l06dPwb12KyC33wYRX6H+yvOZaFT8cA66/NzRk+MAZDwPvmVOaFcVpdW4lqptT+Xgf2GO43HhoHceKg==",
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
       "requires": {
-        "@readme/oas-extensions": "^14.0.0",
-        "oas": "^17.1.0",
-        "parse-data-url": "^4.0.1"
-      }
-    },
-    "@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-        "@apidevtools/openapi-schemas": "^2.1.0",
-        "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.1.0",
-        "ajv": "^8.6.3",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       },
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-          "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.3",
-            "@types/json-schema": "^7.0.6",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^4.1.0"
-          }
-        },
-        "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-draft-04": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-          "requires": {}
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -12622,6 +12581,62 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        }
+      }
+    },
+    "@readme/oas-examples": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
+      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
+      "dev": true
+    },
+    "@readme/oas-extensions": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.3.tgz",
+      "integrity": "sha512-Z2bDImkmNSzHK98Rga5fTThculu3vF0Yhcr7/L8Sux1j+msPrkj6LoV0nIiG+42GcRoZHe5az8e/1PRTqP5rtA==",
+      "requires": {}
+    },
+    "@readme/oas-to-har": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-14.0.4.tgz",
+      "integrity": "sha512-bEXDrzgn17ScrGhzQHwAwosyimq8UzbVs8j72SDmZwxzUAsnGb8x1sOyz2DqCF0GVz0+p3F9jfbq2ii94ILvNQ==",
+      "requires": {
+        "@readme/oas-extensions": "^14.0.3",
+        "oas": "^17.3.2",
+        "parse-data-url": "^4.0.1"
+      }
+    },
+    "@readme/openapi-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "requires": {
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-draft-04": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -14048,13 +14063,6 @@
         "is-set": "^2.0.2",
         "is-string": "^1.0.5",
         "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
       }
     },
     "es-to-primitive": {
@@ -14613,9 +14621,9 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "38.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-38.0.1.tgz",
-      "integrity": "sha512-eu4HCg7Bv43nk/hYZoWpLzRo668Nb7swQySn94aohn0heh9KLJ1GOFgVxJndLS8BploMGaClxgsyTNGJrP69yw==",
+      "version": "39.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-39.0.0.tgz",
+      "integrity": "sha512-fd5RK2FtYjGcIx3wra7csIE/wkkmBo22T1gZtRTsLr1Mb+KsFKJ+JOdSqhHXQUrI/JTs/Mon64cEYzTgSCbltw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -15714,6 +15722,11 @@
       "requires": {
         "call-bind": "^1.0.0"
       }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -17911,11 +17924,12 @@
       "dev": true
     },
     "oas": {
-      "version": "17.1.7",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.7.tgz",
-      "integrity": "sha512-BWXhaJPC0OywIpSRKcD6dIhyCqBQOkUBpKcx7bQ1yz9WG3k5T0ooC8E/Co/ywK28txTqHG2PSisxw2Xb1J4y/w==",
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
+      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@types/json-schema": "^7.0.9",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -17925,10 +17939,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^4.1.5"
+        "swagger-inline": "^5.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -17961,11 +17975,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.1.tgz",
-      "integrity": "sha512-GJStwIAjiJdHbzsqI5E492yL5duhG1Mrnbp0smRx5NEN/BkiFqPJDTG7JtI3VBKdHA023TUeCD3/XoKkg5a14g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "requires": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -18105,9 +18119,9 @@
       }
     },
     "openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -19033,9 +19047,9 @@
       }
     },
     "swagger-inline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
-      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
+      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "url": "git://github.com/readmeio/oas-to-snippet.git"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16",
-    "npm": "^7"
+    "node": "^12 || ^14 || ^16"
   },
   "scripts": {
     "lint": "eslint .",
@@ -23,15 +22,15 @@
   },
   "dependencies": {
     "@readme/httpsnippet": "^3.0.1",
-    "@readme/oas-to-har": "^14.0.2",
+    "@readme/oas-to-har": "^14.0.4",
     "httpsnippet-client-api": "^4.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
-    "@readme/eslint-config": "^8.0.2",
+    "@readme/eslint-config": "^8.0.4",
     "@readme/oas-examples": "^4.3.2",
-    "@readme/oas-extensions": "^14.0.0",
+    "@readme/oas-extensions": "^14.0.3",
     "datauri": "^4.1.0",
     "eslint": "^8.2.0",
     "har-examples": "^2.0.1",


### PR DESCRIPTION
## 🧰 What's being changed?

Installing this library with npm@8 generates a warning that it actually wants npm@7. Since either work, and the npm requirement is only really there for local development I'm removing it.

## 🧬 Testing

* [ ] Tests pass?