### PR TITLE
feat: documenting an install command for httpie

### DIFF
--- a/src/supportedLanguages.js
+++ b/src/supportedLanguages.js
@@ -226,7 +226,10 @@ module.exports = {
             indent: '     ',
           },
         },
-        httpie: { name: 'HTTPie' },
+        httpie: {
+          name: 'HTTPie',
+          install: 'brew install httpie',
+        },
       },
     },
   },


### PR DESCRIPTION
| 🚥 Fix RM-3100 |
| :-- |

## 🧰 Changes

Adds an install step command for the HTTPie shell target.