### PR TITLE
chore: rename `fetch` to `node-fetch`

### DIFF
--- a/src/supportedLanguages.js
+++ b/src/supportedLanguages.js
@@ -121,7 +121,7 @@ module.exports = {
           install: 'npm install axios --save',
         },
         fetch: {
-          name: 'fetch',
+          name: 'node-fetch',
           install: 'npm install node-fetch --save',
         },
         native: { name: 'http' },


### PR DESCRIPTION
## 🧰 Changes

Since Node v18 has an actual `fetch` implementation, this clarifies the name of our `fetch` target to indicate that it's `node-fetch`. I decided to leave the key for this as is since we haven't added the proper `fetch` target yet.
