### PR TITLE
fix: updating oas-to-har to fix issues with files that have underscores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@readme/httpsnippet": "^4.0.5",
-        "@readme/oas-to-har": "^17.1.0",
+        "@readme/oas-to-har": "^17.1.1",
         "httpsnippet-client-api": "^5.0.0-beta.2"
       },
       "devDependencies": {
@@ -2470,6 +2470,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@readme/eslint-config": {
       "version": "8.8.3",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.8.3.tgz",
@@ -2565,13 +2573,13 @@
       }
     },
     "node_modules/@readme/oas-to-har": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.0.tgz",
-      "integrity": "sha512-GEH9DB3K7+/vvm0VvSStglz0DB2NHh7WfNYd7dgxUtLMwFOWxV71iCgs/kqbQ3KXD0V111s92D0W3Hvar0y+ng==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.1.tgz",
+      "integrity": "sha512-Afqz6qI27RzeG4zeI4Xd/pKRiXsnLEZUsjAecxbNBIKUaG42UPUyXthA1Xn1UKLKoT5Fcov5bVUu32m4hs722Q==",
       "dependencies": {
+        "@readme/data-urls": "^1.0.0",
         "@readme/oas-extensions": "^14.3.0",
         "oas": "^18.3.1",
-        "parse-data-url": "^4.0.1",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       },
@@ -13334,17 +13342,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "dependencies": {
-        "valid-data-url": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -17026,14 +17023,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "node_modules/valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -19954,6 +19943,11 @@
         }
       }
     },
+    "@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w=="
+    },
     "@readme/eslint-config": {
       "version": "8.8.3",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.8.3.tgz",
@@ -20033,13 +20027,13 @@
       "requires": {}
     },
     "@readme/oas-to-har": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.0.tgz",
-      "integrity": "sha512-GEH9DB3K7+/vvm0VvSStglz0DB2NHh7WfNYd7dgxUtLMwFOWxV71iCgs/kqbQ3KXD0V111s92D0W3Hvar0y+ng==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-17.1.1.tgz",
+      "integrity": "sha512-Afqz6qI27RzeG4zeI4Xd/pKRiXsnLEZUsjAecxbNBIKUaG42UPUyXthA1Xn1UKLKoT5Fcov5bVUu32m4hs722Q==",
       "requires": {
+        "@readme/data-urls": "^1.0.0",
         "@readme/oas-extensions": "^14.3.0",
         "oas": "^18.3.1",
-        "parse-data-url": "^4.0.1",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       },
@@ -28617,14 +28611,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "requires": {
-        "valid-data-url": "^4.0.0"
-      }
-    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -31597,11 +31583,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@readme/httpsnippet": "^4.0.5",
-    "@readme/oas-to-har": "^17.1.0",
+    "@readme/oas-to-har": "^17.1.1",
     "httpsnippet-client-api": "^5.0.0-beta.2"
   },
   "devDependencies": {


### PR DESCRIPTION
| 🚥 Fix RM-3195 |
| :-- |

## 🧰 Changes

Updates `@readme/oas-to-har` to pull in the work in https://github.com/readmeio/oas-to-har/pull/110 to swap out [parse-data-url](https://npm.im/parse-data-url) with our fork, [@readme/data-urls](https://npm.im/@readme/data-urls), that supports file names with underscores.