### PR TITLE
feat: upgrading httpsnippet-client-api to have headers in api snippets lowercased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@readme/httpsnippet": "^4.0.5",
         "@readme/oas-to-har": "^17.1.2",
-        "httpsnippet-client-api": "^5.0.0-beta.2"
+        "httpsnippet-client-api": "^5.0.0-beta.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.0.3",
@@ -9790,9 +9790,9 @@
       }
     },
     "node_modules/httpsnippet-client-api": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-5.0.0-beta.2.tgz",
-      "integrity": "sha512-CQylwo4BghxzUhxvWwOUKNBKDW+rmOExauKv2camaptXP50DW8BZJmhjXPGhuFsEqGEsYQJ58AhFhyFTtMmnpQ==",
+      "version": "5.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-5.0.0-beta.3.tgz",
+      "integrity": "sha512-miRoQZdHOXCavmnhF1dEv7HkU7ztZs3JzVmvGiCyAg//EbMR3f/Qr0Jo9lCO6P2ZctS6fHKENHb2cYMLuJAScw==",
       "dependencies": {
         "content-type": "^1.0.4",
         "stringify-object": "^3.3.0"
@@ -9802,7 +9802,7 @@
       },
       "peerDependencies": {
         "@readme/httpsnippet": "^4.0.3",
-        "oas": "^18.0.1"
+        "oas": "^18.3.4"
       }
     },
     "node_modules/human-signals": {
@@ -26041,9 +26041,9 @@
       }
     },
     "httpsnippet-client-api": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-5.0.0-beta.2.tgz",
-      "integrity": "sha512-CQylwo4BghxzUhxvWwOUKNBKDW+rmOExauKv2camaptXP50DW8BZJmhjXPGhuFsEqGEsYQJ58AhFhyFTtMmnpQ==",
+      "version": "5.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-5.0.0-beta.3.tgz",
+      "integrity": "sha512-miRoQZdHOXCavmnhF1dEv7HkU7ztZs3JzVmvGiCyAg//EbMR3f/Qr0Jo9lCO6P2ZctS6fHKENHb2cYMLuJAScw==",
       "requires": {
         "content-type": "^1.0.4",
         "stringify-object": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@readme/httpsnippet": "^4.0.5",
     "@readme/oas-to-har": "^17.1.2",
-    "httpsnippet-client-api": "^5.0.0-beta.2"
+    "httpsnippet-client-api": "^5.0.0-beta.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",

--- a/test/__datasets__/languages/node/api.js
+++ b/test/__datasets__/languages/node/api.js
@@ -1,5 +1,5 @@
 module.exports = `const sdk = require('api')('https://example.com/openapi.json');
 
-sdk.loginUser({username: 'woof', password: 'barkbarkbark', Accept: 'application/xml'})
+sdk.loginUser({username: 'woof', password: 'barkbarkbark', accept: 'application/xml'})
   .then(res => console.log(res))
   .catch(err => console.error(err));`;


### PR DESCRIPTION
## 🧰 Changes

* [x] Headers in `api` snippets are now always going to be lowercased.
* [x] Fixed a bug in `api` snippets where in `multipart/form-data` requests we were unnecessarily surfacing multipart boundary information. `api` handles this automatically so we don't need it in snippets.