### PR TITLE
feat: rewriting the library in typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
-node_modules/
+.nyc_output/
 coverage/
+dist/
+node_modules/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
-  "extends": "@readme/eslint-config",
+  "extends": [
+    "@readme/eslint-config",
+    "@readme/eslint-config/typescript"
+  ],
   "root": true
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
     commit-message:
       prefix: chore(deps)
       prefix-development: chore(deps-dev)
+    ignore:
+      # These can't be upgraded because `@jsdevtools/karma-config@3` still requires Webpack 4.
+      - dependency-name: ts-loader
+        versions:
+          - "> 8"
+      - dependency-name: webpack
+        versions:
+          - "> 4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -65,14 +65,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install npm@8
-        run: npm install -g npm@8
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npx mocha
+      - run: npm ci
+      - run: npm run build
+      - run: npx mocha
 
   browser_tests:
     name: Browser
@@ -109,11 +104,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install npm@8
-        run: npm install -g npm@8
-
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
+      - run: npm run build
 
       # Chrome
       - uses: browser-actions/setup-chrome@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Get npm cache directory
         id: npm-cache-dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output/
 coverage/
+dist/
 node_modules/

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,12 @@
 {
-  "watch-files": ["src/*.js", "test/**/*.js"],
+  "require": [
+    "test/helpers/init.js",
+    "ts-node/register"
+  ],
+  "watch-extensions": [
+    "ts"
+  ],
+  "watch-files": ["src/**/*.ts", "test/**/*.js", "test/**/*.ts"],
   "recursive": true,
   "reporter": "spec"
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
+.nyc_output/
 coverage/
+dist/

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ npm install --save @readme/oas-to-snippet
 ## Usage
 
 ```js
-const Oas = require('oas');
-const generateSnippet = require('@readme/oas-to-snippet');
+import Oas from 'oas';
+import generateSnippet from '@readme/oas-to-snippet';
 
 const apiDefinition = new Oas('petstore.json');
 const operation = apiDefinition.operation('/pets', 'get');

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ npm install --save @readme/oas-to-snippet
 ```js
 import Oas from 'oas';
 import generateSnippet from '@readme/oas-to-snippet';
+import petstore from './petstore.json';
 
-const apiDefinition = new Oas('petstore.json');
+const apiDefinition = new Oas(petstore);
 const operation = apiDefinition.operation('/pets', 'get');
 
 // This is a keyed object containing formData for your operation. Available keys are: path,

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ const formData = {
 // its value should either be a String, or an Object containing `user` and/or `pass` (for Basic
 // auth schemes).
 const auth = {
-  'oauth2': 'bearerToken',
-}
+  oauth2: 'bearerToken',
+};
 
 // This is the language to generate a snippet to. See below for supported languages.
 //
@@ -59,40 +59,40 @@ const { code, highlightMode } = generateSnippet(apiDefinition, operation, formDa
 
 Since this library uses [HTTP Snippet](https://github.com/Kong/httpsnippet), we support most of its languages, and their associated targets, which are the following:
 
-* `c`
-* `clojure`
-* `cplusplus`
-* `csharp`
-  * `httpclient`
-  * `restsharp`
-* `curl`
-* `go`
-* `java`
-  * `asynchttp`
-  * `nethttp`
-  * `okhttp`
-  * `unirest`
-* `javascript`
-  * `axios`
-  * `fetch`
-  * `jquery`
-  * `xhr`
-* `kotlin`
-  * `okhttp`
-* `node`
-  * `api`: This is our OpenAPI-powered SDK generation library; see https://npm.im/api for more info.
-  * `axios`
-  * `fetch`
-  * `native`
-  * `request`
-* `node-simple`: This is a shortcut for supplying `['node', 'api']` as the `lang` argument.
-* `objectivec`
-* `ocaml`
-* `php`
-  * `curl`
-* `powershell`
-* `python`
-  * `requests`
-* `r`
-* `ruby`
-* `swift`
+- `c`
+- `clojure`
+- `cplusplus`
+- `csharp`
+  - `httpclient`
+  - `restsharp`
+- `curl`
+- `go`
+- `java`
+  - `asynchttp`
+  - `nethttp`
+  - `okhttp`
+  - `unirest`
+- `javascript`
+  - `axios`
+  - `fetch`
+  - `jquery`
+  - `xhr`
+- `kotlin`
+  - `okhttp`
+- `node`
+  - `api`: This is our OpenAPI-powered SDK generation library; see https://npm.im/api for more info.
+  - `axios`
+  - `fetch`
+  - `native`
+  - `request`
+- `node-simple`: This is a shortcut for supplying `['node', 'api']` as the `lang` argument.
+- `objectivec`
+- `ocaml`
+- `php`
+  - `curl`
+- `powershell`
+- `python`
+  - `requests`
+- `r`
+- `ruby`
+- `swift`

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { karmaConfig } = require('@jsdevtools/karma-config');
 const { host } = require('@jsdevtools/host-environment');
 
@@ -10,5 +11,17 @@ module.exports = karmaConfig({
     safari: host.os.mac,
     edge: false,
     ie: false,
+  },
+  tests: ['test/*.ts'],
+  config: {
+    webpack: {
+      resolve: {
+        extensions: ['.js', '.ts'],
+      },
+      mode: 'production',
+      module: {
+        rules: [{ test: /\.ts$/, use: 'ts-loader' }],
+      },
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "prettier": "^2.7.1",
         "ts-loader": "^8.4.0",
         "ts-node": "^10.9.1",
+        "type-fest": "^2.18.0",
         "typescript": "^4.7.4",
         "webpack": "^4.46.0"
       },
@@ -16955,6 +16956,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -31804,6 +31817,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
       "dev": true
     },
     "type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "prettier": "^2.7.1",
         "ts-loader": "^8.4.0",
         "ts-node": "^10.9.1",
-        "type-fest": "^2.18.0",
         "typescript": "^4.7.4",
         "webpack": "^4.46.0"
       },
@@ -16956,18 +16955,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -31817,12 +31804,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
       "dev": true
     },
     "type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@readme/eslint-config": "^9.0.0",
         "@readme/oas-examples": "^5.4.1",
         "@readme/oas-extensions": "^14.2.0",
+        "@types/chai": "^4.3.1",
+        "@types/har-format": "^1.2.8",
+        "@types/mocha": "^9.1.1",
         "chai": "^4.3.6",
         "eslint": "^8.20.0",
         "har-examples": "^3.1.1",
@@ -28,7 +31,12 @@
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "oas": "^18.2.2",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "ts-loader": "^8.4.0",
+        "ts-node": "^10.9.1",
+        "type-fest": "^2.18.0",
+        "typescript": "^4.7.4",
+        "webpack": "^4.46.0"
       },
       "engines": {
         "node": ">=14"
@@ -2811,6 +2819,12 @@
         "@types/responselike": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "dev": true
+    },
     "node_modules/@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -2831,6 +2845,12 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
@@ -2868,6 +2888,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3503,6 +3529,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -16754,10 +16791,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+      "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "*"
+      }
+    },
+    "node_modules/ts-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -16884,11 +16957,15 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -16921,9 +16998,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20466,6 +20543,12 @@
         "@types/responselike": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "dev": true
+    },
     "@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -20486,6 +20569,12 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true,
       "peer": true
+    },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
@@ -20523,6 +20612,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@types/node": {
@@ -21016,6 +21111,13 @@
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "requires": {
         "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+        }
       }
     },
     "ansi-regex": {
@@ -31603,10 +31705,35 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "ts-loader": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+      "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^2.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -31693,9 +31820,10 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -31724,9 +31852,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "prettier": "^2.7.1",
     "ts-loader": "^8.4.0",
     "ts-node": "^10.9.1",
-    "type-fest": "^2.18.0",
     "typescript": "^4.7.4",
     "webpack": "^4.46.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@readme/oas-to-snippet",
   "description": "Transform an OpenAPI operation into a code snippet",
   "version": "17.1.0",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": "Jon Ursenbach <jon@readme.io>",
   "license": "MIT",
   "repository": {
@@ -13,15 +14,18 @@
     "node": ">=14"
   },
   "scripts": {
+    "build": "tsc",
     "lint": "eslint .",
+    "prebuild": "rm -rf dist/",
+    "prepack": "npm run build",
     "prepare": "husky install",
-    "pretest": "npm run lint",
-    "prettier": "prettier --list-different --write \"./**/**.{js}\"",
+    "__pretest": "npm run lint",
+    "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
     "release": "npx conventional-changelog-cli -i CHANGELOG.md -s && git add CHANGELOG.md",
+    "test": "nyc mocha \"test/**/*.test.ts\"",
     "test:browser": "karma start --single-run",
     "test:browser:chrome": "karma start --browsers=Chrome --single-run=false",
-    "test:browser:debug": "karma start --single-run=false",
-    "test": "nyc mocha"
+    "test:browser:debug": "karma start --single-run=false"
   },
   "dependencies": {
     "@readme/httpsnippet": "^4.0.5",
@@ -36,6 +40,9 @@
     "@readme/eslint-config": "^9.0.0",
     "@readme/oas-examples": "^5.4.1",
     "@readme/oas-extensions": "^14.2.0",
+    "@types/chai": "^4.3.1",
+    "@types/har-format": "^1.2.8",
+    "@types/mocha": "^9.1.1",
     "chai": "^4.3.6",
     "eslint": "^8.20.0",
     "har-examples": "^3.1.1",
@@ -43,7 +50,12 @@
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "oas": "^18.2.2",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "ts-loader": "^8.4.0",
+    "ts-node": "^10.9.1",
+    "type-fest": "^2.18.0",
+    "typescript": "^4.7.4",
+    "webpack": "^4.46.0"
   },
   "prettier": "@readme/eslint-config/prettier",
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
     "prepare": "husky install",
-    "__pretest": "npm run lint",
+    "pretest": "npm run lint",
     "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
     "release": "npx conventional-changelog-cli -i CHANGELOG.md -s && git add CHANGELOG.md",
     "test": "nyc mocha \"test/**/*.test.ts\"",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prettier": "^2.7.1",
     "ts-loader": "^8.4.0",
     "ts-node": "^10.9.1",
+    "type-fest": "^2.18.0",
     "typescript": "^4.7.4",
     "webpack": "^4.46.0"
   },

--- a/src/supportedLanguages.ts
+++ b/src/supportedLanguages.ts
@@ -1,4 +1,26 @@
-module.exports = {
+import type { ClientId, TargetId } from '@readme/httpsnippet/dist/targets/targets';
+
+export type SupportedTargets = Exclude<TargetId, 'objc'> | 'cplusplus' | 'objectivec';
+export type SupportedLanguages = Record<
+  SupportedTargets,
+  {
+    highlight: string;
+    httpsnippet: {
+      lang: TargetId;
+      default: ClientId;
+      targets: Record<
+        ClientId,
+        {
+          name: string;
+          install?: string;
+          opts?: Record<string, unknown>;
+        }
+      >;
+    };
+  }
+>;
+
+const supportedLanguages: SupportedLanguages = {
   c: {
     highlight: 'text/x-csrc',
     httpsnippet: {
@@ -244,3 +266,5 @@ module.exports = {
     },
   },
 };
+
+export default supportedLanguages;

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+
+process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json');
+process.env.NODE_ENV = 'development';

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": false,
+    "resolveJsonModule": true
+  },
+  "include": ["../src/**/*", "*.ts", "**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./src",
+    "declaration": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "lib": ["dom", "ESNext"],
+    "noImplicitAny": true,
+    "outDir": "dist/"
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
## 🧰 Changes

* [x] Rewrites the library in Typescript like I did with `@readme/oas-to-har` in https://github.com/readmeio/oas-to-har/pull/113.
* [x] **Finally** creates types for our `supportedLanguages` config.

## 🧬 QA & Testing

Aside from some minor typing coercion on the optional `harOverride` parameter so TS would accept it no functionality changes have been introduced here so all tests should be/are passing.