### PR TITLE
fix: refactoring the main export so it's easier to load in ES environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save @readme/oas-to-snippet
 
 ```js
 import Oas from 'oas';
-import generateSnippet from '@readme/oas-to-snippet';
+import { oasToSnippet } from '@readme/oas-to-snippet';
 import petstore from './petstore.json';
 
 const apiDefinition = new Oas(petstore);
@@ -53,7 +53,7 @@ const url = 'https://example.com/petstore.json';
 // This will return an object containing `code` and `highlightMode`. `code` is the generated code
 // snippet, while `highlightMode` is the language mode you can use to render it for syntax
 // highlighting (with @readme/syntax-highlighter, for example).
-const { code, highlightMode } = generateSnippet(apiDefinition, operation, formData, auth, language, url);
+const { code, highlightMode } = oasToSnippet(apiDefinition, operation, formData, auth, language, url);
 ```
 
 ## Supported Languages

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import supportedLanguages from './supportedLanguages';
 
 export type { AuthForHAR, DataForHAR, SupportedTargets, SupportedLanguages };
 
-export default function oasToSnippet(
+export function oasToSnippet(
   oas: Oas,
   operation: Operation,
   values: DataForHAR,


### PR DESCRIPTION
## 🧰 Changes

Current doing `import { default as oasToSnippet } from '@readme/oas-to-snippet'` still requires you to do `oasToSnippet.default()`. This simplifies the main export so there's no longer a named `default` export.