### PR TITLE
feat: changing the indent level of JSON payloads in cURL snippets to be 2 characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "21.0.1",
       "license": "MIT",
       "dependencies": {
-        "@readme/httpsnippet": "^5.0.0",
+        "@readme/httpsnippet": "^5.1.0",
         "@readme/oas-to-har": "^20.1.1",
         "httpsnippet-client-api": "^5.0.7"
       },
@@ -24,7 +24,7 @@
         "@types/chai": "^4.3.1",
         "@types/har-format": "^1.2.8",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^18.14.4",
+        "@types/node": "^18.14.6",
         "chai": "^4.3.6",
         "eslint": "^8.35.0",
         "har-examples": "^3.1.1",
@@ -32,7 +32,7 @@
         "mocha": "^10.2.0",
         "mocha-chai-jest-snapshot": "^1.1.4",
         "nyc": "^15.1.0",
-        "oas": "^20.5.0",
+        "oas": "^20.5.3",
         "prettier": "^2.8.4",
         "ts-loader": "^8.4.0",
         "ts-node": "^10.9.1",
@@ -2737,9 +2737,9 @@
       }
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-5.0.0.tgz",
-      "integrity": "sha512-Xtaf68DeaMsHY1P9GOJfVgSIygRsUzkR+e7z8xPe3kfoGV3RJ1hOe8l3MutEqAgmRujYnb4Pm/HxD5kzdndoJQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-5.1.0.tgz",
+      "integrity": "sha512-lzvxlmbbBh+Ijhwv5AbRk09yeKiC3A90hPzJK5sIVGuGk3fnkxvtJOYd0jznpY84AHtRhJ+A/DbTFS8ngkxLYg==",
       "dependencies": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
@@ -3101,9 +3101,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.4.tgz",
-      "integrity": "sha512-VhCw7I7qO2X49+jaKcAUwi3rR+hbxT5VcYF493+Z5kMLI0DL568b7JI4IDJaxWFH0D/xwmGJNoXisyX+w7GH/g==",
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -13722,9 +13722,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-20.5.0.tgz",
-      "integrity": "sha512-257D5i4ZFdQp1CLazP2ODPk7LjE20yehO5ZBbnoWaY7b9szzA3aaa4E0MkpwhRLD6VSLdBBdKFGGtJtkpiCdhw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-20.5.3.tgz",
+      "integrity": "sha512-HrLf4ARLUDfzZ6wC3L1/0MAG+izCfH4OB/RtwsEkzN26ptjmLxifadFC1D2vsXNfdd6oztt1ZbLpYekcBUY+cQ==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",
@@ -21173,9 +21173,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-5.0.0.tgz",
-      "integrity": "sha512-Xtaf68DeaMsHY1P9GOJfVgSIygRsUzkR+e7z8xPe3kfoGV3RJ1hOe8l3MutEqAgmRujYnb4Pm/HxD5kzdndoJQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-5.1.0.tgz",
+      "integrity": "sha512-lzvxlmbbBh+Ijhwv5AbRk09yeKiC3A90hPzJK5sIVGuGk3fnkxvtJOYd0jznpY84AHtRhJ+A/DbTFS8ngkxLYg==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
@@ -21490,9 +21490,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.4.tgz",
-      "integrity": "sha512-VhCw7I7qO2X49+jaKcAUwi3rR+hbxT5VcYF493+Z5kMLI0DL568b7JI4IDJaxWFH0D/xwmGJNoXisyX+w7GH/g==",
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -29938,9 +29938,9 @@
       }
     },
     "oas": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-20.5.0.tgz",
-      "integrity": "sha512-257D5i4ZFdQp1CLazP2ODPk7LjE20yehO5ZBbnoWaY7b9szzA3aaa4E0MkpwhRLD6VSLdBBdKFGGtJtkpiCdhw==",
+      "version": "20.5.3",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-20.5.3.tgz",
+      "integrity": "sha512-HrLf4ARLUDfzZ6wC3L1/0MAG+izCfH4OB/RtwsEkzN26ptjmLxifadFC1D2vsXNfdd6oztt1ZbLpYekcBUY+cQ==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:browser:debug": "karma start --single-run=false"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^5.0.0",
+    "@readme/httpsnippet": "^5.1.0",
     "@readme/oas-to-har": "^20.1.1",
     "httpsnippet-client-api": "^5.0.7"
   },
@@ -43,7 +43,7 @@
     "@types/chai": "^4.3.1",
     "@types/har-format": "^1.2.8",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^18.14.4",
+    "@types/node": "^18.14.6",
     "chai": "^4.3.6",
     "eslint": "^8.35.0",
     "har-examples": "^3.1.1",
@@ -51,7 +51,7 @@
     "mocha": "^10.2.0",
     "mocha-chai-jest-snapshot": "^1.1.4",
     "nyc": "^15.1.0",
-    "oas": "^20.5.0",
+    "oas": "^20.5.3",
     "prettier": "^2.8.4",
     "ts-loader": "^8.4.0",
     "ts-node": "^10.9.1",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -154,6 +154,54 @@ fetch(url, options)
      --data 'b=1,2,3'`);
   });
 
+  it('should have special indents in curl snippets for JSON payloads', function () {
+    const oas = Oas.init({
+      paths: {
+        '/body': {
+          get: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { code } = oasToSnippet(
+      oas,
+      oas.operation('/body', 'get'),
+      { body: { a: 'test', b: [1, 2, 3] } },
+      {},
+      'curl'
+    );
+
+    expect(code).to.equal(`curl --request GET \\
+     --url https://example.com/body \\
+     --header 'content-type: application/json' \\
+     --data '
+{
+  "a": "test",
+  "b": [
+    1,
+    2,
+    3
+  ]
+}
+'`);
+  });
+
   it('should not contain proxy url', function () {
     const oas = new Oas({
       ...JSON.parse(JSON.stringify(petstoreOas)),


### PR DESCRIPTION
## 🧰 Changes

Updates [@readme/httpsnippet](https://npm.im/@readme/httpsnippet) to incorporate https://github.com/readmeio/httpsnippet/commit/637825b276adb91dff4106c91a9f98c202d3d202 where I changed the indent level of JSON payloads in cURL snippets to be hardcoded to 2 characters instead of the library-supplied `indent` option that we set to 5 characters within this library.

The end result is cURL snippets with JSON payloads that are a lot nicer to look at.

#### Before

![before](https://user-images.githubusercontent.com/33762/223587558-9c8bf5e8-9431-432d-af3f-8db235606207.png)

#### After

![after](https://user-images.githubusercontent.com/33762/223587716-27f746d1-5788-442e-9390-5fde85d74dfd.png)