### PR TITLE
feat: creation of a new JSON target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "22.0.2",
       "license": "MIT",
       "dependencies": {
-        "@readme/httpsnippet": "^6.1.0",
+        "@readme/httpsnippet": "^6.2.0",
         "@readme/oas-to-har": "^21.0.1",
         "httpsnippet-client-api": "^6.0.1"
       },
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/@readme/httpsnippet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-6.1.0.tgz",
-      "integrity": "sha512-H3rReBBJ2Jjh1GS+xM9+Z9Ur5JxsqxPVxjmstRDY8eehLaZm4MBqMWfbGfvoDcivfYE9OHHZJWREmYG1Jz+HKA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-6.2.0.tgz",
+      "integrity": "sha512-ySLD6c8s54JvkmLaLLax/LgC3LY4u61XNqBWmtNDBUDKzcXkNfQQIabwIVxpnf3/BMJt0WAHC/vxLIu8XOvIUw==",
       "dependencies": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",
@@ -11678,9 +11678,9 @@
       }
     },
     "@readme/httpsnippet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-6.1.0.tgz",
-      "integrity": "sha512-H3rReBBJ2Jjh1GS+xM9+Z9Ur5JxsqxPVxjmstRDY8eehLaZm4MBqMWfbGfvoDcivfYE9OHHZJWREmYG1Jz+HKA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-6.2.0.tgz",
+      "integrity": "sha512-ySLD6c8s54JvkmLaLLax/LgC3LY4u61XNqBWmtNDBUDKzcXkNfQQIabwIVxpnf3/BMJt0WAHC/vxLIu8XOvIUw==",
       "requires": {
         "event-stream": "4.0.1",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/httpsnippet": "^6.1.0",
+    "@readme/httpsnippet": "^6.2.0",
     "@readme/oas-to-har": "^21.0.1",
     "httpsnippet-client-api": "^6.0.1"
   },

--- a/src/supportedLanguages.ts
+++ b/src/supportedLanguages.ts
@@ -114,6 +114,16 @@ const supportedLanguages: SupportedLanguages = {
       },
     },
   },
+  json: {
+    highlight: 'json',
+    httpsnippet: {
+      lang: 'json',
+      default: 'native',
+      targets: {
+        native: { name: 'JSON' },
+      },
+    },
+  },
   kotlin: {
     highlight: 'java',
     httpsnippet: {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -25,6 +25,8 @@ struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "content-type: application/json");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
+curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
+
 CURLcode ret = curl_easy_perform(hnd);"
 `;
 
@@ -45,7 +47,8 @@ CURLcode ret = curl_easy_perform(hnd);"
 exports[`oas-to-snippet supported languages clojure should generate code for the default target 1`] = `
 "(require '[clj-http.client :as client])
 
-(client/post "http://petstore.swagger.io/v2/pet" {:headers {:content-type "application/json"}})"
+(client/post "http://petstore.swagger.io/v2/pet" {:content-type :json
+                                                  :form-params {:name "buster"}})"
 `;
 
 exports[`oas-to-snippet supported languages clojure targets clj_http should support snippet generation 1`] = `
@@ -66,6 +69,8 @@ curl_easy_setopt(hnd, CURLOPT_URL, "http://petstore.swagger.io/v2/pet");
 struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "content-type: application/json");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
 
 CURLcode ret = curl_easy_perform(hnd);"
 `;
@@ -91,7 +96,7 @@ exports[`oas-to-snippet supported languages csharp should generate code for the 
 var options = new RestClientOptions("http://petstore.swagger.io/v2/pet");
 var client = new RestClient(options);
 var request = new RestRequest("");
-request.AddHeader("content-type", "application/json");
+request.AddJsonBody("{\\"name\\":\\"buster\\"}", false);
 var response = await client.PostAsync(request);
 
 Console.WriteLine("{0}", response.Content);
@@ -137,6 +142,7 @@ exports[`oas-to-snippet supported languages go should generate code for the defa
 
 import (
 	"fmt"
+	"strings"
 	"net/http"
 	"io"
 )
@@ -145,7 +151,9 @@ func main() {
 
 	url := "http://petstore.swagger.io/v2/pet"
 
-	req, _ := http.NewRequest("POST", url, nil)
+	payload := strings.NewReader("{\\"name\\":\\"buster\\"}")
+
+	req, _ := http.NewRequest("POST", url, payload)
 
 	req.Header.Add("content-type", "application/json")
 
@@ -190,8 +198,9 @@ exports[`oas-to-snippet supported languages http should generate code for the de
 "POST /v2/pet HTTP/1.1
 Content-Type: application/json
 Host: petstore.swagger.io
+Content-Length: 17
 
-"
+{"name":"buster"}"
 `;
 
 exports[`oas-to-snippet supported languages http targets http1.1 should support snippet generation 1`] = `
@@ -205,9 +214,11 @@ Host: petstore.swagger.io
 exports[`oas-to-snippet supported languages java should generate code for the default target 1`] = `
 "OkHttpClient client = new OkHttpClient();
 
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{\\"name\\":\\"buster\\"}");
 Request request = new Request.Builder()
   .url("http://petstore.swagger.io/v2/pet")
-  .post(null)
+  .post(body)
   .addHeader("content-type", "application/json")
   .build();
 
@@ -255,7 +266,11 @@ exports[`oas-to-snippet supported languages java targets unirest should support 
 `;
 
 exports[`oas-to-snippet supported languages javascript should generate code for the default target 1`] = `
-"const options = {method: 'POST', headers: {'content-type': 'application/json'}};
+"const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: JSON.stringify({name: 'buster'})
+};
 
 fetch('http://petstore.swagger.io/v2/pet', options)
   .then(response => response.json())
@@ -326,12 +341,22 @@ xhr.setRequestHeader('accept', 'application/json');
 xhr.send(data);"
 `;
 
+exports[`oas-to-snippet supported languages json should generate code for the default target 1`] = `
+"{
+  "name": "buster"
+}"
+`;
+
+exports[`oas-to-snippet supported languages json targets native should support snippet generation 1`] = `""`;
+
 exports[`oas-to-snippet supported languages kotlin should generate code for the default target 1`] = `
 "val client = OkHttpClient()
 
+val mediaType = MediaType.parse("application/json")
+val body = RequestBody.create(mediaType, "{\\"name\\":\\"buster\\"}")
 val request = Request.Builder()
   .url("http://petstore.swagger.io/v2/pet")
-  .post(null)
+  .post(body)
   .addHeader("content-type", "application/json")
   .build()
 
@@ -354,7 +379,11 @@ exports[`oas-to-snippet supported languages node should generate code for the de
 "const fetch = require('node-fetch');
 
 const url = 'http://petstore.swagger.io/v2/pet';
-const options = {method: 'POST', headers: {'content-type': 'application/json'}};
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: JSON.stringify({name: 'buster'})
+};
 
 fetch(url, options)
   .then(res => res.json())
@@ -450,12 +479,16 @@ exports[`oas-to-snippet supported languages objectivec should generate code for 
 "#import <Foundation/Foundation.h>
 
 NSDictionary *headers = @{ @"content-type": @"application/json" };
+NSDictionary *parameters = @{ @"name": @"buster" };
+
+NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://petstore.swagger.io/v2/pet"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                    timeoutInterval:10.0];
 [request setHTTPMethod:@"POST"];
 [request setAllHTTPHeaderFields:headers];
+[request setHTTPBody:postData];
 
 NSURLSession *session = [NSURLSession sharedSession];
 NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
@@ -501,8 +534,9 @@ open Lwt
 
 let uri = Uri.of_string "http://petstore.swagger.io/v2/pet" in
 let headers = Header.add (Header.init ()) "content-type" "application/json" in
+let body = Cohttp_lwt_body.of_string "{\\"name\\":\\"buster\\"}" in
 
-Client.call ~headers \`POST uri
+Client.call ~headers ~body \`POST uri
 >>= fun (res, body_stream) ->
   (* Do stuff with the result *)"
 `;
@@ -527,6 +561,7 @@ require_once('vendor/autoload.php');
 $client = new \\GuzzleHttp\\Client();
 
 $response = $client->request('POST', 'http://petstore.swagger.io/v2/pet', [
+  'body' => '{"name":"buster"}',
   'headers' => [
     'content-type' => 'application/json',
   ],
@@ -583,7 +618,7 @@ echo $response->getBody();"
 exports[`oas-to-snippet supported languages powershell should generate code for the default target 1`] = `
 "$headers=@{}
 $headers.Add("content-type", "application/json")
-$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/pet' -Method POST -Headers $headers"
+$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/pet' -Method POST -Headers $headers -ContentType 'application/json' -Body '{"name":"buster"}'"
 `;
 
 exports[`oas-to-snippet supported languages powershell targets restmethod should support snippet generation 1`] = `
@@ -603,9 +638,10 @@ exports[`oas-to-snippet supported languages python should generate code for the 
 
 url = "http://petstore.swagger.io/v2/pet"
 
+payload = { "name": "buster" }
 headers = {"content-type": "application/json"}
 
-response = requests.post(url, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)"
 `;
@@ -627,7 +663,11 @@ exports[`oas-to-snippet supported languages r should generate code for the defau
 
 url <- "http://petstore.swagger.io/v2/pet"
 
-response <- VERB("POST", url, content_type("application/octet-stream"))
+payload <- "{\\"name\\":\\"buster\\"}"
+
+encode <- "json"
+
+response <- VERB("POST", url, body = payload, content_type("application/json"), encode = encode)
 
 content(response, "text")"
 `;
@@ -657,6 +697,7 @@ http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
+request.body = "{\\"name\\":\\"buster\\"}"
 
 response = http.request(request)
 puts response.read_body"
@@ -680,7 +721,8 @@ puts response.read_body"
 exports[`oas-to-snippet supported languages shell should generate code for the default target 1`] = `
 "curl --request POST \\
      --url http://petstore.swagger.io/v2/pet \\
-     --header 'content-type: application/json'"
+     --header 'content-type: application/json' \\
+     --data '{"name":"buster"}'"
 `;
 
 exports[`oas-to-snippet supported languages shell targets curl should support snippet generation 1`] = `
@@ -698,12 +740,16 @@ exports[`oas-to-snippet supported languages swift should generate code for the d
 "import Foundation
 
 let headers = ["content-type": "application/json"]
+let parameters = ["name": "buster"] as [String : Any]
+
+let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
 
 let request = NSMutableURLRequest(url: NSURL(string: "http://petstore.swagger.io/v2/pet")! as URL,
                                         cachePolicy: .useProtocolCachePolicy,
                                     timeoutInterval: 10.0)
 request.httpMethod = "POST"
 request.allHTTPHeaderFields = headers
+request.httpBody = postData as Data
 
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,7 +17,14 @@ import multipartFormDataOneOfRequestBody from './__datasets__/quirks/multipart-o
 const petstore = Oas.init(petstoreOas);
 
 const oasUrl = 'https://example.com/openapi.json';
-const formData = { path: { petId: 123 } };
+const formData = {
+  path: {
+    petId: 123,
+  },
+  body: {
+    name: 'buster',
+  },
+};
 
 describe('oas-to-snippet', function () {
   describe('HAR overrides', function () {


### PR DESCRIPTION
| 🚥 RM-7177 |
| :---------------- |

## 🧰 Changes

This updates `@readme/httpsnippet` to pull in a new `json` snippet target that will JSONify any payload (`postData.params` or `postData.text`). It does nothing with server URLS, query params, headers, cookies, anything other than payloads are ignored. It's not super useful for seeing what a request you'll need to make will be but a customer of ours wants this so we've gotta have it!