### PR TITLE
docs: markdown table with targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 16
           cache: npm
 
-      - run: npm ci
+      - run: npm ci && npm run build
       - run: npm run lint
 
   test:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ npm run build && node bin/generate-target-markdown-table.js
  -->
 
 <!-- prettier-ignore-start -->
+<!-- table-start -->
 | Language | Available language mode(s) | Libraries (if applicable)
 | :---- | :---- | :---- |
 | C | `c` | [Libcurl](http://curl.haxx.se/libcurl)
@@ -89,4 +90,5 @@ npm run build && node bin/generate-target-markdown-table.js
 | Ruby | `ruby` | [net::http](http://ruby-doc.org/stdlib-2.2.1/libdoc/net/http/rdoc/Net/HTTP.html)
 | Shell | `shell` | [cURL](http://curl.haxx.se/), [HTTPie](http://httpie.org/), [Wget](https://www.gnu.org/software/wget/)
 | Swift | `swift` | [NSURLSession](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html)
+<!-- table-end -->
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npm run build && node bin/generate-target-markdown-table.js
 | JavaScript | `javascript` | [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), [Axios](https://github.com/axios/axios), [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), [jQuery](http://api.jquery.com/jquery.ajax/)
 | JSON | `json` | [Native JSON](https://www.json.org/json-en.html)
 | Kotlin | `kotlin` | [OkHttp](http://square.github.io/okhttp/)
-| Node.js | `node` | [HTTP](http://nodejs.org/api/http.html#http_http_request_options_callback), [Request](https://github.com/request/request), [Unirest](http://unirest.io/nodejs.html), [Axios](https://github.com/axios/axios), [Fetch](https://github.com/bitinn/node-fetch)
+| Node.js | `node` | [`api`](https://api.readme.dev), [HTTP](http://nodejs.org/api/http.html#http_http_request_options_callback), [Request](https://github.com/request/request), [Unirest](http://unirest.io/nodejs.html), [Axios](https://github.com/axios/axios), [Fetch](https://github.com/bitinn/node-fetch)
 | Objective-C | `objectivec` | [NSURLSession](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html)
 | OCaml | `ocaml` | [CoHTTP](https://github.com/mirage/ocaml-cohttp)
 | PHP | `php` | [cURL](http://php.net/manual/en/book.curl.php), [Guzzle](http://docs.guzzlephp.org/en/stable/), [HTTP v1](http://php.net/manual/en/book.http.php), [HTTP v2](http://devel-m6w6.rhcloud.com/mdref/http)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ const { code, highlightMode } = oasToSnippet(apiDefinition, operation, formData,
 
 Since this library uses [HTTP Snippet](https://github.com/Kong/httpsnippet), we support most of its languages, and their associated targets, which are the following:
 
+<!--
+To regenerate the table below, run the following:
+
+npm run build && node bin/generate-target-markdown-table.js
+ -->
+
 <!-- prettier-ignore-start -->
 | Language | Available language mode(s) | Libraries (if applicable)
 | :---- | :---- | :---- |

--- a/README.md
+++ b/README.md
@@ -60,43 +60,27 @@ const { code, highlightMode } = oasToSnippet(apiDefinition, operation, formData,
 
 Since this library uses [HTTP Snippet](https://github.com/Kong/httpsnippet), we support most of its languages, and their associated targets, which are the following:
 
-- `c`
-- `clojure`
-- `cplusplus`
-- `csharp`
-  - `httpclient`
-  - `restsharp`
-- `http`
-- `go`
-- `java`
-  - `asynchttp`
-  - `nethttp`
-  - `okhttp`
-  - `unirest`
-- `javascript`
-  - `axios`
-  - `fetch`
-  - `jquery`
-  - `xhr`
-- `kotlin`
-- `node`
-  - `api`: This is our OpenAPI-powered SDK generation library; see https://npm.im/api for more info.
-  - `axios`
-  - `fetch`
-  - `native`
-  - `request`
-- `objectivec`
-- `ocaml`
-- `php`
-  - `curl`
-  - `guzzle`
-- `powershell`
-  - `restmethod`
-  - `webrequest`
-- `python`
-- `r`
-- `ruby`
-- `shell`
-  - `curl`
-  - `httpie`
-- `swift`
+<!-- prettier-ignore-start -->
+| Language | Available language mode(s) | Libraries (if applicable)
+| :---- | :---- | :---- |
+| C | `c` | [Libcurl](http://curl.haxx.se/libcurl)
+| Clojure | `clojure` | [clj-http](https://github.com/dakrone/clj-http)
+| C++ | `cplusplus` | [Libcurl](http://curl.haxx.se/libcurl)
+| C# | `csharp` | [HttpClient](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient), [RestSharp](http://restsharp.org/)
+| HTTP | `http` | [HTTP/1.1](https://tools.ietf.org/html/rfc7230)
+| Go | `go` | [NewRequest](http://golang.org/pkg/net/http/#NewRequest)
+| Java | `java` | [AsyncHttp](https://github.com/AsyncHttpClient/async-http-client), [java.net.http](https://openjdk.java.net/groups/net/httpclient/intro.html), [OkHttp](http://square.github.io/okhttp/), [Unirest](http://unirest.io/java.html)
+| JavaScript | `javascript` | [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), [Axios](https://github.com/axios/axios), [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), [jQuery](http://api.jquery.com/jquery.ajax/)
+| JSON | `json` | [Native JSON](https://www.json.org/json-en.html)
+| Kotlin | `kotlin` | [OkHttp](http://square.github.io/okhttp/)
+| Node.js | `node` | [HTTP](http://nodejs.org/api/http.html#http_http_request_options_callback), [Request](https://github.com/request/request), [Unirest](http://unirest.io/nodejs.html), [Axios](https://github.com/axios/axios), [Fetch](https://github.com/bitinn/node-fetch)
+| Objective-C | `objectivec` | [NSURLSession](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html)
+| OCaml | `ocaml` | [CoHTTP](https://github.com/mirage/ocaml-cohttp)
+| PHP | `php` | [cURL](http://php.net/manual/en/book.curl.php), [Guzzle](http://docs.guzzlephp.org/en/stable/), [HTTP v1](http://php.net/manual/en/book.http.php), [HTTP v2](http://devel-m6w6.rhcloud.com/mdref/http)
+| Powershell | `powershell` | [Invoke-WebRequest](https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Utility/Invoke-WebRequest), [Invoke-RestMethod](https://docs.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Utility/Invoke-RestMethod)
+| Python | `python` | [Requests](http://docs.python-requests.org/en/latest/api/#requests.request)
+| R | `r` | [httr](https://cran.r-project.org/web/packages/httr/vignettes/quickstart.html)
+| Ruby | `ruby` | [net::http](http://ruby-doc.org/stdlib-2.2.1/libdoc/net/http/rdoc/Net/HTTP.html)
+| Shell | `shell` | [cURL](http://curl.haxx.se/), [HTTPie](http://httpie.org/), [Wget](https://www.gnu.org/software/wget/)
+| Swift | `swift` | [NSURLSession](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLSession_class/index.html)
+<!-- prettier-ignore-end -->

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { availableTargets } = require('@readme/httpsnippet');
 
@@ -30,7 +31,8 @@ function run() {
       // Corresponding httpsnippet target object
       const httpsnippetTarget = getTarget(httpsnippetLang);
 
-      // C++ and Objective-C are weird in that their
+      // C++ is weird in that it uses the httpsnippet data for C but this library
+      // represents it as a separate language
       if (lang === 'cplusplus') {
         languageTitle = 'C++';
       } else {
@@ -52,6 +54,7 @@ function run() {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error('Error generating Markdown Table!');
+    // eslint-disable-next-line no-console
     console.error(e);
     return process.exit(1);
   }

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -3,7 +3,7 @@
 const { availableTargets } = require('@readme/httpsnippet');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const supportedLanguages = require('../dist/supportedLanguages');
+const supportedLanguages = require('../dist/supportedLanguages.js');
 
 const targets = availableTargets();
 

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -1,5 +1,8 @@
 #! /usr/bin/env node
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs/promises');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { availableTargets } = require('@readme/httpsnippet');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -14,12 +17,9 @@ function getTarget(targetKey) {
 /**
  * Generates a Markdown table that documents all supported snippets.
  */
-function run() {
+async function run() {
   try {
-    // eslint-disable-next-line no-console
-    console.log('| Language | Available language mode(s) | Libraries (if applicable)');
-    // eslint-disable-next-line no-console
-    console.log('| :---- | :---- | :---- |');
+    const output = ['| Language | Available language mode(s) | Libraries (if applicable)', '| :---- | :---- | :---- |'];
 
     Object.keys(supportedLanguages.default).forEach(lang => {
       let languageTitle = 'TKTK';
@@ -50,13 +50,26 @@ function run() {
         libraries.unshift('[`api`](https://api.readme.dev)');
       }
 
-      // eslint-disable-next-line no-console
-      console.log(`| ${languageTitle} | \`${languageMode}\` | ${libraries.join(', ')}`.trim());
+      output.push(`| ${languageTitle} | \`${languageMode}\` | ${libraries.join(', ')}`.trim());
     });
+
+    // Update README.md
+    const readmeFile = await fs.readFile('README.md', { encoding: 'utf-8' });
+
+    const updatedFile = readmeFile.replace(
+      // https://stackoverflow.com/a/24375554
+      /<!-- table-start -->([\S\s]*?)<!-- table-end -->/g,
+      `<!-- table-start -->\n${output.join('\n')}\n<!-- table-end -->`,
+    );
+
+    await fs.writeFile('README.md', updatedFile, { encoding: 'utf-8' });
+
+    // eslint-disable-next-line no-console
+    console.log('Table updated!');
     return process.exit(0);
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('Error generating Markdown Table!');
+    console.error('Error updating Markdown Table!');
     // eslint-disable-next-line no-console
     console.error(e);
     return process.exit(1);

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -1,0 +1,62 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { availableTargets } = require('@readme/httpsnippet');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const supportedLanguages = require('../dist/supportedLanguages');
+
+const targets = availableTargets();
+
+function getTarget(targetKey) {
+  return targets.find(target => target.key === targetKey);
+}
+
+/**
+ * Generates a Markdown table that documents all supported snippets.
+ */
+function run() {
+  try {
+    // eslint-disable-next-line no-console
+    console.log('| Language | Available language mode(s) | Libraries (if applicable)');
+    // eslint-disable-next-line no-console
+    console.log('| :---- | :---- | :---- |');
+
+    Object.keys(supportedLanguages.default).forEach(lang => {
+      let languageTitle = 'TKTK';
+      const languageMode = lang;
+      let libraries = '';
+
+      // Corresponding language in httpsnippet library
+      const httpsnippetLang = supportedLanguages.default[lang].httpsnippet.lang;
+      // Corresponding httpsnippet target object
+      const httpsnippetTarget = getTarget(httpsnippetLang);
+
+      // C++ and Objective-C are weird in that their
+      if (lang === 'cplusplus') {
+        languageTitle = 'C++';
+      } else if (lang === 'objectivec') {
+        languageTitle = 'Objective-C';
+      } else {
+        languageTitle = httpsnippetTarget.title;
+      }
+
+      if (httpsnippetTarget?.clients.length) {
+        libraries = httpsnippetTarget.clients
+          .map(client => {
+            return `[${client.title}](${client.link})`;
+          })
+          .join(', ');
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(`| ${languageTitle} | \`${languageMode}\` | ${libraries}`.trim());
+    });
+    return process.exit(0);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Error generating Markdown Table!');
+    console.error(e);
+    return process.exit(1);
+  }
+}
+
+run();

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -24,7 +24,7 @@ function run() {
     Object.keys(supportedLanguages.default).forEach(lang => {
       let languageTitle = 'TKTK';
       const languageMode = lang;
-      let libraries = '';
+      let libraries = [];
 
       // Corresponding language in httpsnippet library
       const httpsnippetLang = supportedLanguages.default[lang].httpsnippet.lang;
@@ -40,15 +40,18 @@ function run() {
       }
 
       if (httpsnippetTarget?.clients.length) {
-        libraries = httpsnippetTarget.clients
-          .map(client => {
-            return `[${client.title}](${client.link})`;
-          })
-          .join(', ');
+        libraries = httpsnippetTarget.clients.map(client => {
+          return `[${client.title}](${client.link})`;
+        });
+      }
+
+      // backfill `api` since we're grabbing the clients list from httpsnippet
+      if (lang === 'node') {
+        libraries.unshift('[`api`](https://api.readme.dev)');
       }
 
       // eslint-disable-next-line no-console
-      console.log(`| ${languageTitle} | \`${languageMode}\` | ${libraries}`.trim());
+      console.log(`| ${languageTitle} | \`${languageMode}\` | ${libraries.join(', ')}`.trim());
     });
     return process.exit(0);
   } catch (e) {

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -6,7 +6,7 @@ const fs = require('fs/promises');
 const { availableTargets } = require('@readme/httpsnippet');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const supportedLanguages = require('../dist/supportedLanguages.js');
+const supportedLanguages = require('../dist/supportedLanguages');
 
 const targets = availableTargets();
 

--- a/bin/generate-target-markdown-table.js
+++ b/bin/generate-target-markdown-table.js
@@ -33,8 +33,6 @@ function run() {
       // C++ and Objective-C are weird in that their
       if (lang === 'cplusplus') {
         languageTitle = 'C++';
-      } else if (lang === 'objectivec') {
-        languageTitle = 'Objective-C';
       } else {
         languageTitle = httpsnippetTarget.title;
       }


### PR DESCRIPTION
## 🧰 Changes

Went down a rabbit hole and ended up writing a little `bin` script to dynamically generate a Markdown table containing all of our different HTTPSnippet targets.

## 🧬 QA & Testing

This is untested but I want to get some doc updates out in a few places and isn't used in the `oas-to-snippet` library itself so I think this is fine for now, but let me know if you disagree!
